### PR TITLE
IG-7892: Make authoritative servers handle their zone serials correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ None of the variables below are required.
 | :---                       | :---    | :---                                                                                                                                                      |
 | `dnsmasq_no_hosts`         | -       | Set this to prevent reading hostnames from  `/etc/hosts`.                                                                   |
 | `dnsmasq_addn_hosts`       | -       | Set this to specify a custom host file that should be read in addition to `/etc/hosts`.                                                                   |
-| `dnsmasq_authoritative`    | `false` | When `true`, dnsmasq will function as an authoritative name server.                                                                                       |
+| `dnsmasq_authoritative`    | `false` | When `true`, dnsmasq will function as an authoritative name server. Requires setting `dnsmasq_domain` and `dnsmasq_interface`.                              |
 | `dnsmasq_bogus_priv`       | `true`  | When `true`, Dnsmasq will not forward addresses in the non-routed address spaces.                                                                         |
 | `dnsmasq_dhcp_hosts`       | -       | Array of hashes specifying IP address reservations for hosts, with keys `name` (optional), `mac` and `ip` for each reservation. See below.             |
 | `dnsmasq_dhcp_ranges`      | -       | Array of hashes specifying DHCP ranges (with keys `start_addr`, `end_addr`, and `lease_time`) for each address pool. This also enables DHCP. See below. |

--- a/templates/etc_dnsmasq.conf.j2
+++ b/templates/etc_dnsmasq.conf.j2
@@ -69,6 +69,8 @@ server={{ dnsmasq_upstream_servers }}
 
 {% if dnsmasq_authoritative %}
 dhcp-authoritative
+# Set auth-server so we also get the zone SOA serial set by timestamp
+auth-server={{ dnsmasq_domain }},{{ dnsmasq_interface }}
 {% endif %}
 
 {% if dnsmasq_srv_hosts is defined %}

--- a/templates/etc_dnsmasq.conf.j2
+++ b/templates/etc_dnsmasq.conf.j2
@@ -70,7 +70,7 @@ server={{ dnsmasq_upstream_servers }}
 {% if dnsmasq_authoritative %}
 dhcp-authoritative
 # Set auth-server so we also get the zone SOA serial set by timestamp
-auth-server={{ dnsmasq_domain }},{{ dnsmasq_interface }}
+auth-server={{ dnsmasq_domain|mandatory }},{{ dnsmasq_interface|mandatory }}
 {% endif %}
 
 {% if dnsmasq_srv_hosts is defined %}


### PR DESCRIPTION
Have the `dnsmasq_authoritative` setting also configure `auth-server`.
This setting seems optional, but turns out to trigger the authoritative
zone serial number being generated by timestamp.
When this is not used, restarting dnsmasq resets the zone serial to 1,
which confuses any zone slaves.